### PR TITLE
Require PHP 8.4 and add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
+        php-versions: ['8.4', '8.5']
         dependency-versions: [ 'highest', 'lowest' ]
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
   "require": {
     "doctrine/doctrine-bundle": "^2.12",
     "giggsey/libphonenumber-for-php": "^8.13",
-    "php": "^8.3",
+    "php": "^8.4",
     "symfony/http-kernel": "^7.0",
     "symfony/validator": "^7.0",
     "egulias/email-validator": "^3.2|^4.0",


### PR DESCRIPTION
## Summary
- Bump minimum PHP requirement from `^8.3` to `^8.4` in `composer.json`
- Replace PHP 8.3 with PHP 8.5 in the CI test matrix (keeping PHP 8.4)

## Test plan
- [ ] CI passes on PHP 8.4 and 8.5 with lowest/highest dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)