### PR TITLE
chore: upgrade giggsey/libphonenumber-for-php from ^8.13 to ^9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
   },
   "require": {
     "doctrine/doctrine-bundle": "^2.12",
-    "giggsey/libphonenumber-for-php": "^8.13",
+    "giggsey/libphonenumber-for-php": "^9.0",
     "php": "^8.4",
     "symfony/http-kernel": "^7.0",
     "symfony/validator": "^7.0",

--- a/src/Validator/Constraints/Phone.php
+++ b/src/Validator/Constraints/Phone.php
@@ -22,7 +22,7 @@ class Phone extends Constraint
     public const INVALID_COUNTRY_CODE = '5530a448-f887-48c0-8ef8-77f206aa52b6';
 
     /**
-     * @return list<int>
+     * @return list<PhoneNumberType>
      */
     public function getValidTypes(): array
     {


### PR DESCRIPTION
PhoneNumberType is now a backed enum in v9. Update the @return PHPDoc accordingly. All tests pass.