### PR TITLE
add modulo 97 checksum validation to BelgianEnterpriseNumberValidator

### DIFF
--- a/src/Validator/Constraints/BelgianEnterpriseNumber.php
+++ b/src/Validator/Constraints/BelgianEnterpriseNumber.php
@@ -10,5 +10,7 @@ use Symfony\Component\Validator\Constraint;
 class BelgianEnterpriseNumber extends Constraint
 {
     public const string WRONG_FORMAT_ERROR = '3f7d2e1c-a845-4b9f-c631-52d78e04fb6a';
+    public const string INVALID_CHECKSUM_ERROR = 'b4e8f1a2-c739-4d56-8e0a-1f2b3c4d5e6f';
     public const string MESSAGE = 'The Belgian Enterprise Number {{ value }} is not valid.';
+    public const string INVALID_CHECKSUM_MESSAGE = 'The Belgian Enterprise Number {{ value }} has an invalid checksum.';
 }

--- a/src/Validator/Constraints/BelgianEnterpriseNumberValidator.php
+++ b/src/Validator/Constraints/BelgianEnterpriseNumberValidator.php
@@ -30,6 +30,18 @@ class BelgianEnterpriseNumberValidator extends ConstraintValidator
                 ->setParameter('{{ value }}', $this->formatValue($value))
                 ->setCode($constraint::WRONG_FORMAT_ERROR)
                 ->addViolation();
+            return;
+        }
+
+        $base = (int) substr($value, 0, 8);
+        $expectedChecksum = 97 - ($base % 97);
+        $actualChecksum = (int) substr($value, 8, 2);
+
+        if ($expectedChecksum !== $actualChecksum) {
+            $this->context->buildViolation($constraint::INVALID_CHECKSUM_MESSAGE)
+                ->setParameter('{{ value }}', $this->formatValue($value))
+                ->setCode($constraint::INVALID_CHECKSUM_ERROR)
+                ->addViolation();
         }
     }
 }

--- a/tests/Validator/Constraints/BelgianEnterpriseNumberValidatorTest.php
+++ b/tests/Validator/Constraints/BelgianEnterpriseNumberValidatorTest.php
@@ -29,24 +29,29 @@ class BelgianEnterpriseNumberValidatorTest extends ConstraintValidatorTestCase
     {
         yield 'null value' => [null];
         yield 'empty string' => [''];
-        yield 'valid number starting with 0' => ['0123456789'];
-        yield 'valid number starting with 1' => ['1234567890'];
-        yield 'valid number starting with 0 all zeros' => ['0000000000'];
-        yield 'valid number starting with 1 all digits' => ['1999999999'];
+        yield 'valid number starting with 0' => ['0123456749'];
+        yield 'valid number starting with 1' => ['1234567894'];
+        yield 'valid number starting with 0 all zeros' => ['0000000097'];
+        yield 'valid number starting with 1 all digits' => ['1999999943'];
     }
 
     public static function providerInvalidValues(): iterable
     {
-        $expectedMessage = BelgianEnterpriseNumber::MESSAGE;
-        $code = BelgianEnterpriseNumber::WRONG_FORMAT_ERROR;
+        $formatMessage = BelgianEnterpriseNumber::MESSAGE;
+        $formatCode = BelgianEnterpriseNumber::WRONG_FORMAT_ERROR;
+        $checksumMessage = BelgianEnterpriseNumber::INVALID_CHECKSUM_MESSAGE;
+        $checksumCode = BelgianEnterpriseNumber::INVALID_CHECKSUM_ERROR;
 
-        yield 'too short' => ['012345678', $code, $expectedMessage];
-        yield 'too long' => ['01234567890', $code, $expectedMessage];
-        yield 'starts with 2' => ['2123456789', $code, $expectedMessage];
-        yield 'starts with 9' => ['9123456789', $code, $expectedMessage];
-        yield 'contains letters' => ['012345678A', $code, $expectedMessage];
-        yield 'contains special characters' => ['01234-6789', $code, $expectedMessage];
-        yield 'contains spaces' => ['0123 56789', $code, $expectedMessage];
-        yield 'single digit' => ['0', $code, $expectedMessage];
+        yield 'too short' => ['012345678', $formatCode, $formatMessage];
+        yield 'too long' => ['01234567890', $formatCode, $formatMessage];
+        yield 'starts with 2' => ['2123456789', $formatCode, $formatMessage];
+        yield 'starts with 9' => ['9123456789', $formatCode, $formatMessage];
+        yield 'contains letters' => ['012345678A', $formatCode, $formatMessage];
+        yield 'contains special characters' => ['01234-6789', $formatCode, $formatMessage];
+        yield 'contains spaces' => ['0123 56789', $formatCode, $formatMessage];
+        yield 'single digit' => ['0', $formatCode, $formatMessage];
+        yield 'wrong checksum starting with 0' => ['0123456789', $checksumCode, $checksumMessage];
+        yield 'wrong checksum starting with 1' => ['1234567890', $checksumCode, $checksumMessage];
+        yield 'wrong checksum all zeros' => ['0000000000', $checksumCode, $checksumMessage];
     }
 }


### PR DESCRIPTION
Adds the BCE checksum check: 97 - (first 8 digits % 97) must equal the last 2 digits. Invalid checksum is reported with a dedicated INVALID_CHECKSUM_ERROR code distinct from WRONG_FORMAT_ERROR.