### PR TITLE
Convert @dataProvider annotations to #[DataProvider] attributes

### DIFF
--- a/src/Test/ConstraintValidatorTestCase.php
+++ b/src/Test/ConstraintValidatorTestCase.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AssoConnect\ValidatorBundle\Test;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintValidator;
@@ -35,9 +36,7 @@ abstract class ConstraintValidatorTestCase extends SymfonyConstraintValidatorTes
         $this->validator->validate(0, new NotBlank());
     }
 
-    /**
-     * @dataProvider providerValidValues
-     */
+    #[DataProvider('providerValidValues')]
     public function testValidValues(mixed $value): void
     {
         $this->validator->validate($value, $this->getConstraint());
@@ -51,9 +50,9 @@ abstract class ConstraintValidatorTestCase extends SymfonyConstraintValidatorTes
     abstract public static function providerValidValues(): iterable;
 
     /**
-     * @dataProvider providerInvalidValues
      * @param array<string, mixed>|null $parameters
      */
+    #[DataProvider('providerInvalidValues')]
     public function testInvalidValues(mixed $value, string $code, string $message, ?array $parameters = null): void
     {
         $this->validator->validate($value, $this->getConstraint());

--- a/src/Test/FieldConstraintsSetProviderTestCase.php
+++ b/src/Test/FieldConstraintsSetProviderTestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AssoConnect\ValidatorBundle\Test;
 
 use AssoConnect\ValidatorBundle\Validator\ConstraintsSetProvider\Field\FieldConstraintsSetProviderInterface;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Validator\Constraint;
 
@@ -20,8 +21,8 @@ abstract class FieldConstraintsSetProviderTestCase extends TestCase
     /**
      * @param mixed[] $fieldMapping
      * @param Constraint[] $constraints
-     * @dataProvider getConstraintsForTypeProvider
      */
+    #[DataProvider('getConstraintsForTypeProvider')]
     public function testGetConstraintsForType(array $fieldMapping, array $constraints): void
     {
         $factory = $this->getFactory();


### PR DESCRIPTION
PHPUnit 12 dropped support for metadata in doc-comments, so the @dataProvider annotations in the ConstraintValidatorTestCase and FieldConstraintsSetProviderTestCase base classes were no longer wired up: consumer tests extending them failed with ArgumentCountError under PHPUnit 12+. Attributes are supported from PHPUnit 10, so this stays compatible with the current PHPUnit 11 toolchain.