### PR TITLE
Add Doctrine ORM 3 support alongside ORM 2.20

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "jeremykendall/php-domain-parser": "^6.0",
     "moneyphp/money": "^3.0|^4.0",
     "assoconnect/php-date": "^2.0",
-    "doctrine/orm": "^2.7",
+    "doctrine/orm": "^2.20|^3.0",
     "symfony/intl": "^7.0",
     "assoconnect/doctrine-types-bundle": "^v2.16",
     "assoconnect/php-percent":"^1.1",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -8,6 +8,33 @@ parameters:
             - 'Symfony\Component\Validator\Exception\InvalidOptionsException'
             - 'Symfony\Component\Validator\Exception\MissingOptionsException'
 
+    # The errors below depend on which ORM major is installed (^2.20|^3.0 are both supported),
+    # so each analysis run only matches part of them.
+    reportUnmatchedIgnoredErrors: false
+    ignoreErrors:
+        # ORM 3-only mapping classes, unknown when ORM 2 is installed
+        -
+            message: '#Doctrine\\ORM\\Mapping\\(FieldMapping|AssociationMapping|ToOneOwningSideMapping|OneToManyAssociationMapping|ManyToOneAssociationMapping|ManyToManyOwningSideMapping)#'
+            identifier: class.notFound
+        # The tests feed ORM 2 array-shaped mappings into ClassMetadata on both majors on purpose,
+        # and build ORM 3 mapping objects from minimal fixture arrays
+        -
+            path: tests/Validator/Constraints/EntityValidatorTest.php
+            identifier: assign.propertyType
+        -
+            path: tests/Validator/Constraints/EntityValidatorTest.php
+            identifier: argument.type
+        # The ORM 2 (array) / ORM 3 (object) runtime detection is dead code for whichever major is installed
+        -
+            path: src/Validator/Constraints/EntityValidator.php
+            identifier: function.alreadyNarrowedType
+        -
+            path: src/Validator/Constraints/EntityValidator.php
+            identifier: nullCoalesce.offset
+        -
+            path: src/Validator/Constraints/EntityValidator.php
+            identifier: function.impossibleType
+
 includes:
     - vendor/assoconnect/php-quality-config/phpstan.extension.neon
     - ./phpstan-baseline.neon

--- a/src/Test/FieldConstraintsSetProviderTestCase.php
+++ b/src/Test/FieldConstraintsSetProviderTestCase.php
@@ -29,7 +29,6 @@ abstract class FieldConstraintsSetProviderTestCase extends TestCase
         self::assertTrue($factory->supports($fieldMapping['type']));
 
         self::assertArrayContainsSameObjects(
-            /** @phpstan-ignore-next-line */
             $factory->getConstraints($fieldMapping),
             $constraints
         );

--- a/src/Validator/Constraints/EntityValidator.php
+++ b/src/Validator/Constraints/EntityValidator.php
@@ -7,7 +7,9 @@ namespace AssoConnect\ValidatorBundle\Validator\Constraints;
 use AssoConnect\ValidatorBundle\Exception\UnprotectedFieldTypeException;
 use AssoConnect\ValidatorBundle\Validator\ConstraintsSetProvider\Field\FieldConstraintsSetProviderInterface;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\AssociationMapping;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\ToOneOwningSideMapping;
 use Symfony\Component\PropertyAccess\Exception\UnexpectedTypeException;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 use Symfony\Component\Validator\Constraint;
@@ -18,9 +20,6 @@ use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidator;
 use Webmozart\Assert\Assert;
 
-/**
- * @phpstan-import-type FieldMapping from ClassMetadataInfo
- */
 class EntityValidator extends ConstraintValidator
 {
     private EntityManagerInterface $em;
@@ -50,7 +49,7 @@ class EntityValidator extends ConstraintValidator
         Assert::object($entity);
         $class = get_class($entity);
         $metadata = $this->em->getClassMetadata($class);
-        $fields = array_keys($metadata->getReflectionProperties());
+        $fields = array_keys(self::reflectionPropertiesToArray($metadata->getReflectionProperties()));
         $validator = $this->context->getValidator()->inContext($this->context);
         $propertyAccessor = PropertyAccess::createPropertyAccessor();
 
@@ -78,7 +77,7 @@ class EntityValidator extends ConstraintValidator
     }
 
     /**
-     * @param FieldMapping $fieldMapping
+     * @param mixed[] $fieldMapping
      * @return list<Constraint>
      */
     public function getConstraintsForType(array $fieldMapping): array
@@ -102,7 +101,10 @@ class EntityValidator extends ConstraintValidator
         $constraints = [];
 
         if (array_key_exists($field, $metadata->fieldMappings)) {
-            $fieldMapping = $metadata->fieldMappings[$field];
+            $mapping = $metadata->fieldMappings[$field];
+
+            // ORM 3 turns field mappings into objects; normalize to the array shape providers expect
+            $fieldMapping = is_array($mapping) ? $mapping : get_object_vars($mapping);
 
             // Nullable field
             Assert::keyExists($fieldMapping, 'nullable');
@@ -116,33 +118,77 @@ class EntityValidator extends ConstraintValidator
         } elseif (array_key_exists($field, $metadata->embeddedClasses)) {
             $constraints[] = new Valid();
         } elseif (array_key_exists($field, $metadata->associationMappings)) {
-            $fieldMapping = $metadata->associationMappings[$field];
+            $associationMapping = $metadata->associationMappings[$field];
 
-            if (true === $fieldMapping['isOwningSide']) {
-                if (($fieldMapping['type'] & ClassMetadataInfo::TO_ONE) !== 0) {
+            if (is_array($associationMapping)) {
+                // ORM 2
+                $isOwningSide = true === $associationMapping['isOwningSide'];
+                $type = $associationMapping['type'];
+                $targetEntity = $associationMapping['targetEntity'] ?? null;
+                $isJoinColumnNullable = !isset($associationMapping['joinColumns'][0]['nullable'])
+                    || true === $associationMapping['joinColumns'][0]['nullable'];
+            } else {
+                // ORM 3
+                [$isOwningSide, $type, $targetEntity, $isJoinColumnNullable] =
+                    self::extractAssociationMappingValues($associationMapping);
+            }
+
+            if ($isOwningSide) {
+                if (($type & ClassMetadata::TO_ONE) !== 0) {
                     // ToOne
-                    $constraints[] = new Type($fieldMapping['targetEntity']);
+                    $constraints[] = new Type($targetEntity);
                     // Nullable field
-                    if (
-                        isset($fieldMapping['joinColumns'][0]['nullable'])
-                        && true !== $fieldMapping['joinColumns'][0]['nullable']
-                    ) {
+                    if (!$isJoinColumnNullable) {
                         $constraints[] = new NotNull();
                     }
-                } elseif (($fieldMapping['type'] & ClassMetadataInfo::TO_MANY) !== 0) {
+                } elseif (($type & ClassMetadata::TO_MANY) !== 0) {
                     // ToMany
                     $constraints[] = new All(constraints: [
-                        new Type($fieldMapping['targetEntity']),
+                        new Type($targetEntity),
                     ]);
                 } else {
                     // Unknown
-                    throw new \DomainException('Unknown type: ' . $fieldMapping['type']);
+                    throw new \DomainException('Unknown type: ' . $type);
                 }
             }
         } else {
             throw new \LogicException('Unknown field: ' . $class . '::$' . $field);
         }
         return $constraints;
+    }
+
+    /**
+     * ORM 3-only path: coverage depends on the installed ORM major
+     * @codeCoverageIgnore
+     * @return array{bool, int, string, bool}
+     */
+    private static function extractAssociationMappingValues(AssociationMapping $associationMapping): array
+    {
+        $isJoinColumnNullable = true;
+        if ($associationMapping instanceof ToOneOwningSideMapping) {
+            $joinColumn = $associationMapping->joinColumns[0] ?? null;
+            $isJoinColumnNullable = null === $joinColumn || false !== $joinColumn->nullable;
+        }
+
+        return [
+            $associationMapping->isOwningSide(),
+            $associationMapping->type(),
+            $associationMapping->targetEntity,
+            $isJoinColumnNullable,
+        ];
+    }
+
+    /**
+     * ORM 3.5+ may return a LegacyReflectionFields object instead of an array (native lazy objects).
+     * Excluded from coverage: the object path cannot be built without the full metadata factory.
+     *
+     * @codeCoverageIgnore
+     * @param array<string, \ReflectionProperty|null>|\Traversable<string, \ReflectionProperty|null> $properties
+     * @return array<string, \ReflectionProperty|null>
+     */
+    private static function reflectionPropertiesToArray(iterable $properties): array
+    {
+        return $properties instanceof \Traversable ? iterator_to_array($properties, true) : $properties;
     }
 
     private function checkIfFieldNeedsToBeValidated(object $entity, string $field): bool

--- a/src/Validator/ConstraintsSetProvider/Field/ArrayProvider.php
+++ b/src/Validator/ConstraintsSetProvider/Field/ArrayProvider.php
@@ -4,14 +4,16 @@ declare(strict_types=1);
 
 namespace AssoConnect\ValidatorBundle\Validator\ConstraintsSetProvider\Field;
 
-use Doctrine\DBAL\Types\Types;
 use Symfony\Component\Validator\Constraints\Type;
 
 class ArrayProvider implements FieldConstraintsSetProviderInterface
 {
+    // Types::ARRAY was removed in DBAL 4 but legacy columns may still use the type name
+    private const TYPE_ARRAY = 'array';
+
     public function supports(string $type): bool
     {
-        return Types::ARRAY === $type || 'simple_array' === $type;
+        return self::TYPE_ARRAY === $type || 'simple_array' === $type;
     }
 
     public function getConstraints(array $fieldMapping): array

--- a/src/Validator/ConstraintsSetProvider/Field/DecimalProvider.php
+++ b/src/Validator/ConstraintsSetProvider/Field/DecimalProvider.php
@@ -22,6 +22,8 @@ class DecimalProvider implements FieldConstraintsSetProviderInterface
     {
         Assert::keyExists($fieldMapping, 'precision');
         Assert::keyExists($fieldMapping, 'scale');
+        Assert::integer($fieldMapping['precision']);
+        Assert::integer($fieldMapping['scale']);
 
         return [
             new Type('float'),

--- a/src/Validator/ConstraintsSetProvider/Field/FieldConstraintsSetProviderInterface.php
+++ b/src/Validator/ConstraintsSetProvider/Field/FieldConstraintsSetProviderInterface.php
@@ -4,18 +4,17 @@ declare(strict_types=1);
 
 namespace AssoConnect\ValidatorBundle\Validator\ConstraintsSetProvider\Field;
 
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
 use Symfony\Component\Validator\Constraint;
 
-/**
- * @phpstan-import-type FieldMapping from ClassMetadataInfo
- */
 interface FieldConstraintsSetProviderInterface
 {
     public function supports(string $type): bool;
 
     /**
-     * @param FieldMapping $fieldMapping
+     * The field mapping is always the ORM 2 array shape: on ORM 3, EntityValidator
+     * normalizes the FieldMapping object back to an array before calling providers.
+     *
+     * @param mixed[] $fieldMapping
      * @return list<Constraint>
      */
     public function getConstraints(array $fieldMapping): array;

--- a/tests/Validator/Constraints/EntityValidatorTest.php
+++ b/tests/Validator/Constraints/EntityValidatorTest.php
@@ -11,7 +11,11 @@ use AssoConnect\ValidatorBundle\Validator\Constraints\EntityValidator;
 use AssoConnect\ValidatorBundle\Validator\Constraints\Phone;
 use AssoConnect\ValidatorBundle\Validator\ConstraintsSetProvider\Field\PhoneProvider;
 use Doctrine\ORM\EntityManagerInterface;
-use Doctrine\ORM\Mapping\ClassMetadataInfo;
+use Doctrine\ORM\Mapping\ClassMetadata;
+use Doctrine\ORM\Mapping\FieldMapping;
+use Doctrine\ORM\Mapping\ManyToManyOwningSideMapping;
+use Doctrine\ORM\Mapping\ManyToOneAssociationMapping;
+use Doctrine\ORM\Mapping\OneToManyAssociationMapping;
 use Symfony\Component\Validator\Constraint;
 use Symfony\Component\Validator\Constraints\All;
 use Symfony\Component\Validator\Constraints\NotNull;
@@ -20,17 +24,20 @@ use Symfony\Component\Validator\Constraints\Valid;
 use Symfony\Component\Validator\ConstraintValidator;
 
 /**
- * @psalm-import-type FieldMapping from ClassMetadataInfo
  * @extends ConstraintValidatorTestCase<EntityValidator>
  */
 class EntityValidatorTest extends ConstraintValidatorTestCase
 {
     protected EntityManagerInterface $em;
 
+    /** @var ClassMetadata<MyEntityParent> */
+    protected ClassMetadata $classMetadata;
+
     protected function setUp(): void
     {
+        $this->classMetadata = $this->getMockClassMetadata();
         $this->em = $this->createMock(EntityManagerInterface::class);
-        $this->em->method('getClassMetadata')->willReturn($this->getMockClassMetadata());
+        $this->em->method('getClassMetadata')->willReturn($this->classMetadata);
 
         parent::setUp();
     }
@@ -143,6 +150,109 @@ class EntityValidatorTest extends ConstraintValidatorTestCase
         $this->validator->getConstraints('class', 'unknown');
     }
 
+    public function testValidateChecksEveryMappedField(): void
+    {
+        $entity = new class {
+            public readonly ?string $nullable;
+
+            public function __construct()
+            {
+                $this->nullable = '+33611223344';
+            }
+        };
+        $this->classMetadata->reflFields = [
+            'nullable' => new \ReflectionProperty($entity, 'nullable'),
+        ];
+
+        $this->expectValidateValueAt(0, 'nullable', '+33611223344', [new Phone()]);
+
+        $this->validator->validate($entity, new Entity());
+    }
+
+    public function testGetConstraintsForNotNullableFieldWithOrm3MappingObject(): void
+    {
+        self::skipUnlessOrm3();
+
+        $metadata = new ClassMetadata(MyEntityParent::class);
+        $metadata->fieldMappings = [
+            'notnullable' => FieldMapping::fromMappingArray([
+                'type' => 'phone',
+                'fieldName' => 'notnullable',
+                'columnName' => 'notnullable',
+                'nullable' => false,
+            ]),
+        ];
+
+        self::assertArrayContainsSameObjects(
+            $this->createValidatorForMetadata($metadata)->getConstraints('class', 'notnullable'),
+            [new NotNull(), new Phone()]
+        );
+    }
+
+    public function testGetConstraintsForRelationsWithOrm3MappingObjects(): void
+    {
+        self::skipUnlessOrm3();
+
+        $metadata = new ClassMetadata(MyEntityParent::class);
+        $metadata->associationMappings = [
+            'notowning' => OneToManyAssociationMapping::fromMappingArray([
+                'fieldName' => 'notowning',
+                'sourceEntity' => MyEntityParent::class,
+                'targetEntity' => MyEntityParent::class,
+                'mappedBy' => 'parent',
+            ]),
+            'owningToOne' => ManyToOneAssociationMapping::fromMappingArray([
+                'fieldName' => 'owningToOne',
+                'sourceEntity' => MyEntityParent::class,
+                'targetEntity' => MyEntityParent::class,
+            ]),
+            'owningToOneNotNull' => ManyToOneAssociationMapping::fromMappingArray([
+                'fieldName' => 'owningToOneNotNull',
+                'sourceEntity' => MyEntityParent::class,
+                'targetEntity' => MyEntityParent::class,
+                'joinColumns' => [['name' => 'parent_id', 'referencedColumnName' => 'id', 'nullable' => false]],
+            ]),
+            'owningToMany' => ManyToManyOwningSideMapping::fromMappingArray([
+                'fieldName' => 'owningToMany',
+                'sourceEntity' => MyEntityParent::class,
+                'targetEntity' => MyEntityParent::class,
+            ]),
+        ];
+        $validator = $this->createValidatorForMetadata($metadata);
+
+        self::assertEmpty($validator->getConstraints('class', 'notowning'));
+        self::assertArrayContainsSameObjects(
+            $validator->getConstraints('class', 'owningToOne'),
+            [new Type(MyEntityParent::class)]
+        );
+        self::assertArrayContainsSameObjects(
+            $validator->getConstraints('class', 'owningToOneNotNull'),
+            [new Type(MyEntityParent::class), new NotNull()]
+        );
+        self::assertArrayContainsSameObjects(
+            $validator->getConstraints('class', 'owningToMany'),
+            [new All(constraints: [new Type(MyEntityParent::class)])]
+        );
+    }
+
+    private static function skipUnlessOrm3(): void
+    {
+        if (!class_exists(FieldMapping::class)) {
+            self::markTestSkipped('Requires the doctrine/orm 3 mapping objects');
+        }
+    }
+
+    /**
+     * @param ClassMetadata<MyEntityParent> $metadata
+     */
+    private function createValidatorForMetadata(ClassMetadata $metadata): EntityValidator
+    {
+        $em = $this->createMock(EntityManagerInterface::class);
+        $em->method('getClassMetadata')->willReturn($metadata);
+
+        return new EntityValidator($em, [new PhoneProvider()]);
+    }
+
     public static function providerInvalidValues(): iterable
     {
         return [];
@@ -167,9 +277,12 @@ class EntityValidatorTest extends ConstraintValidatorTestCase
         self::markTestSkipped('EntityValidator validates fields based on Doctrine metadata, not raw values');
     }
 
-    private function getMockClassMetadata(): \stdClass
+    /**
+     * @return ClassMetadata<MyEntityParent>
+     */
+    private function getMockClassMetadata(): ClassMetadata
     {
-        $metadata = new \stdClass();
+        $metadata = new ClassMetadata(MyEntityParent::class);
         $metadata->fieldMappings = [
             'nullable' => [
                 'type' => 'phone',
@@ -189,22 +302,22 @@ class EntityValidatorTest extends ConstraintValidatorTestCase
             'notowning' => [
                 'isOwningSide' => false,
                 'targetEntity' => MyEntityParent::class,
-                'type' => ClassMetadataInfo::TO_ONE,
+                'type' => ClassMetadata::TO_ONE,
             ],
             'owningToOne' => [
                 'isOwningSide' => true,
-                'type' => ClassMetadataInfo::TO_ONE,
+                'type' => ClassMetadata::TO_ONE,
                 'targetEntity' => MyEntityParent::class,
             ],
             'owningToOneNotNull' => [
                 'isOwningSide' => true,
-                'type' => ClassMetadataInfo::TO_ONE,
+                'type' => ClassMetadata::TO_ONE,
                 'targetEntity' => MyEntityParent::class,
                 'joinColumns' => [['nullable' => false]],
             ],
             'owningToMany' => [
                 'isOwningSide' => true,
-                'type' => ClassMetadataInfo::TO_MANY,
+                'type' => ClassMetadata::TO_MANY,
                 'targetEntity' => MyEntityParent::class,
             ],
             'owningUnknown' => [


### PR DESCRIPTION
- doctrine/orm constraint: ^2.7 -> ^2.20|^3.0 (CI lowest/highest now covers both majors)
- EntityValidator: normalize ORM 3 FieldMapping objects back to the ORM 2 array shape at the boundary (get_object_vars, no deprecated ArrayAccess) so FieldConstraintsSetProviderInterface::getConstraints(array) and all ~20 providers keep their signature; extract association mapping values dual-style (arrays on ORM 2, typed objects on ORM 3)
- EntityValidator: handle LegacyReflectionFields (ORM 3.5+ native lazy objects) in validate()
- ArrayProvider: drop the Types::ARRAY constant reference (removed in DBAL 4), keep matching the legacy 'array' type name
- DecimalProvider: assert integer precision/scale now that the mapping shape is mixed[]
- Tests: real ClassMetadata instead of stdClass (ORM 3 types getClassMetadata() natively), ORM 3 object-path tests (skipped on ORM 2), new validate() walk test
- phpstan: ignores for the ORM version-conditional branches (each analysis run only sees one major)